### PR TITLE
Transaction rollback on writer flush error

### DIFF
--- a/src/PdoWriter.php
+++ b/src/PdoWriter.php
@@ -101,6 +101,7 @@ class PdoWriter implements Writer, FlushableWriter
 
             $this->pdo->commit();
         } catch (\PDOException $e) {
+            $this->pdo->rollBack();
             throw new WriterException('Failed to write to database', null, $e);
         }
     }


### PR DESCRIPTION
The PDO transaction needed to be closed properly in order to execute other queries afterwards.